### PR TITLE
feat: Flag added to enable failure notifications only

### DIFF
--- a/config/trx-mall-upload-sales-data-api.php
+++ b/config/trx-mall-upload-sales-data-api.php
@@ -39,7 +39,7 @@ return [
         'mail' => [
             'name' => env('TRX_MALL_NOTIFICATION_MAIL_NAME', 'sir/madam'),
             'email' => env('TRX_MALL_NOTIFICATION_MAIL_EMAIL'),
-            'enable_failure_notifications_only' => env('TRX_MALL_NOTIFICATION_MAIL_ENABLE_FAILURE_NOTIFICATIONS_ONLY', false), // This flag determines whether only failure notifications should be received. Set to 'true' to receive only failure notifications, 'false' for all notifications.
+            'trigger_failure_notifications_only' => env('TRX_MALL_NOTIFICATION_MAIL_TRIGGER_FAILURE_NOTIFICATIONS_ONLY', false), // This flag determines whether only failure notifications should be received. Set to 'true' to receive only failure notifications, 'false' for all notifications.
         ],
     ],
 ];

--- a/config/trx-mall-upload-sales-data-api.php
+++ b/config/trx-mall-upload-sales-data-api.php
@@ -39,6 +39,7 @@ return [
         'mail' => [
             'name' => env('TRX_MALL_NOTIFICATION_MAIL_NAME', 'sir/madam'),
             'email' => env('TRX_MALL_NOTIFICATION_MAIL_EMAIL'),
+            'enable_failure_notifications_only' => env('TRX_MALL_NOTIFICATION_MAIL_ENABLE_FAILURE_NOTIFICATIONS_ONLY', false), // This flag determines whether only failure notifications should be received. Set to 'true' to receive only failure notifications, 'false' for all notifications.
         ],
     ],
 ];

--- a/src/Commands/SendSalesCommand.php
+++ b/src/Commands/SendSalesCommand.php
@@ -252,14 +252,14 @@ class SendSalesCommand extends Command
 
     private function notify(string $message, string $status): void
     {
+        if ($status !== 'error' && config('trx_mall_upload_sales_data_api.notifications.mail.enable_failure_notifications_only')) {
+            return;
+        }
+
         if ($email = config('trx_mall_upload_sales_data_api.notifications.mail.email')) {
             $name = config('trx_mall_upload_sales_data_api.notifications.mail.name');
 
-            $isEnabledFailureNotificationsOnly = config('trx_mall_upload_sales_data_api.notifications.mail.enable_failure_notifications_only');
-
-            if (($isEnabledFailureNotificationsOnly && $status == 'error') || ! $isEnabledFailureNotificationsOnly) {
-                Notification::route('mail', $email)->notify(new TrxApiStatusNotification($name, $status, $message));
-            }
+            Notification::route('mail', $email)->notify(new TrxApiStatusNotification($name, $status, $message));
         }
     }
 

--- a/src/Commands/SendSalesCommand.php
+++ b/src/Commands/SendSalesCommand.php
@@ -149,6 +149,7 @@ class SendSalesCommand extends Command
             'api.password' => 'required|string',
             'notifications.mail.name' => 'nullable|string',
             'notifications.mail.email' => 'nullable|email',
+            'notifications.mail.enable_failure_notifications_only' => 'required|boolean',
             'date_of_first_sales_upload' => 'required|date_format:Y-m-d|before_or_equal:today',
         ], [
             '*.required' => $requiredConfigMessage,
@@ -161,6 +162,7 @@ class SendSalesCommand extends Command
             'api.password' => 'TRX_MALL_API_PASSWORD',
             'notifications.mail.name' => 'TRX_MALL_NOTIFICATION_MAIL_NAME',
             'notifications.mail.email' => 'TRX_MALL_NOTIFICATION_MAIL_EMAIL',
+            'notifications.mail.enable_failure_notifications_only' => 'TRX_MALL_NOTIFICATION_MAIL_ENABLE_FAILURE_NOTIFICATIONS_ONLY',
             'date_of_first_sales_upload' => 'TRX_MALL_DATE_OF_FIRST_SALES_UPLOAD',
         ]);
 
@@ -252,8 +254,12 @@ class SendSalesCommand extends Command
     {
         if ($email = config('trx_mall_upload_sales_data_api.notifications.mail.email')) {
             $name = config('trx_mall_upload_sales_data_api.notifications.mail.name');
-            Notification::route('mail', $email)
-                ->notify(new TrxApiStatusNotification($name, $status, $message));
+
+            $isEnabledFailureNotificationsOnly = config('trx_mall_upload_sales_data_api.notifications.mail.enable_failure_notifications_only');
+
+            if (($isEnabledFailureNotificationsOnly && $status == 'error') || ! $isEnabledFailureNotificationsOnly) {
+                Notification::route('mail', $email)->notify(new TrxApiStatusNotification($name, $status, $message));
+            }
         }
     }
 

--- a/src/Commands/SendSalesCommand.php
+++ b/src/Commands/SendSalesCommand.php
@@ -149,7 +149,7 @@ class SendSalesCommand extends Command
             'api.password' => 'required|string',
             'notifications.mail.name' => 'nullable|string',
             'notifications.mail.email' => 'nullable|email',
-            'notifications.mail.enable_failure_notifications_only' => 'required|boolean',
+            'notifications.mail.trigger_failure_notifications_only' => 'required|boolean',
             'date_of_first_sales_upload' => 'required|date_format:Y-m-d|before_or_equal:today',
         ], [
             '*.required' => $requiredConfigMessage,
@@ -162,7 +162,7 @@ class SendSalesCommand extends Command
             'api.password' => 'TRX_MALL_API_PASSWORD',
             'notifications.mail.name' => 'TRX_MALL_NOTIFICATION_MAIL_NAME',
             'notifications.mail.email' => 'TRX_MALL_NOTIFICATION_MAIL_EMAIL',
-            'notifications.mail.enable_failure_notifications_only' => 'TRX_MALL_NOTIFICATION_MAIL_ENABLE_FAILURE_NOTIFICATIONS_ONLY',
+            'notifications.mail.trigger_failure_notifications_only' => 'TRX_MALL_NOTIFICATION_MAIL_TRIGGER_FAILURE_NOTIFICATIONS_ONLY',
             'date_of_first_sales_upload' => 'TRX_MALL_DATE_OF_FIRST_SALES_UPLOAD',
         ]);
 
@@ -252,7 +252,7 @@ class SendSalesCommand extends Command
 
     private function notify(string $message, string $status): void
     {
-        if ($status !== 'error' && config('trx_mall_upload_sales_data_api.notifications.mail.enable_failure_notifications_only')) {
+        if ($status !== 'error' && config('trx_mall_upload_sales_data_api.notifications.mail.trigger_failure_notifications_only')) {
             return;
         }
 

--- a/tests/ConfigPublishTest.php
+++ b/tests/ConfigPublishTest.php
@@ -44,6 +44,6 @@ it('has all required configuration available', function () {
     expect(array_keys($config['notifications']['mail']))->toEqual([
         'name',
         'email',
-        'enable_failure_notifications_only',
+        'trigger_failure_notifications_only',
     ]);
 });

--- a/tests/ConfigPublishTest.php
+++ b/tests/ConfigPublishTest.php
@@ -44,5 +44,6 @@ it('has all required configuration available', function () {
     expect(array_keys($config['notifications']['mail']))->toEqual([
         'name',
         'email',
+        'enable_failure_notifications_only',
     ]);
 });

--- a/tests/SendSalesCommandTest.php
+++ b/tests/SendSalesCommandTest.php
@@ -188,14 +188,14 @@ describe('success cases with notification', function () {
     });
 });
 
-describe('when enable_failure_notifications_only is true', function () {
+describe('when trigger_failure_notifications_only is true', function () {
 
     beforeEach(function () {
         $this->mailConfig = ['name' => 'test', 'email' => 'user@example.com'];
         config([
             'trx_mall_upload_sales_data_api.notifications.mail.name' => $this->mailConfig['name'],
             'trx_mall_upload_sales_data_api.notifications.mail.email' => $this->mailConfig['email'],
-            'trx_mall_upload_sales_data_api.notifications.mail.enable_failure_notifications_only' => true,
+            'trx_mall_upload_sales_data_api.notifications.mail.trigger_failure_notifications_only' => true,
         ]);
     });
 
@@ -239,14 +239,14 @@ describe('when enable_failure_notifications_only is true', function () {
 
 });
 
-describe('when enable_failure_notifications_only is false', function () {
+describe('when trigger_failure_notifications_only is false', function () {
 
     beforeEach(function () {
         $this->mailConfig = ['name' => 'test', 'email' => 'user@example.com'];
         config([
             'trx_mall_upload_sales_data_api.notifications.mail.name' => $this->mailConfig['name'],
             'trx_mall_upload_sales_data_api.notifications.mail.email' => $this->mailConfig['email'],
-            'trx_mall_upload_sales_data_api.notifications.mail.enable_failure_notifications_only' => false,
+            'trx_mall_upload_sales_data_api.notifications.mail.trigger_failure_notifications_only' => false,
         ]);
     });
 

--- a/tests/SendSalesCommandTest.php
+++ b/tests/SendSalesCommandTest.php
@@ -107,10 +107,13 @@ describe('failure cases with notification', function () {
         config([
             'trx_mall_upload_sales_data_api.notifications.mail.name' => $this->mailConfig['name'],
             'trx_mall_upload_sales_data_api.notifications.mail.email' => $this->mailConfig['email'],
+            'trx_mall_upload_sales_data_api.notifications.mail.enable_failure_notifications_only' => true,
         ]);
     });
 
-    it('sends failure notification when no stores found', function () {
+    it('sends failure notification when no stores found', function ($isEnableFailureNotificationsOnly) {
+
+        config()->set('trx_mall_upload_sales_data_api.notifications.mail.enable_failure_notifications_only', $isEnableFailureNotificationsOnly);
 
         $this->serviceMock->shouldReceive('getStores')->once()
             ->andReturn([]);
@@ -118,7 +121,11 @@ describe('failure cases with notification', function () {
         artisan('trx:send-sales', [
             '--date' => '2024-01-11',
         ])->assertExitCode(1);
-    });
+
+    })->with([
+        ['enable_failure_notifications_only' => true],
+        ['enable_failure_notifications_only' => false],
+    ]);
 
     afterEach(function () {
         Notification::assertSentOnDemand(
@@ -159,6 +166,7 @@ describe('success cases with notification', function () {
         config([
             'trx_mall_upload_sales_data_api.notifications.mail.name' => $this->mailConfig['name'],
             'trx_mall_upload_sales_data_api.notifications.mail.email' => $this->mailConfig['email'],
+            'trx_mall_upload_sales_data_api.notifications.mail.enable_failure_notifications_only' => false,
         ]);
     });
 


### PR DESCRIPTION
- Task Link: [Notion Link](https://www.notion.so/IOI-and-TRX-receive-only-failure-notifications-5b802ce0dbb64b20ad139445a6604ce9)

- Description: This PR Contains code related to ```Enable Failure Notifications Only```  


--------------------------------

Please take a minute and verify each of the things below before requesting for a review of your PR.

### Q & A
- [x] I have added new tests and/or updated existing tests as applicable.
- [x] I have done the manual testing to make sure that the coding is done correctly as per the requirements in the Notion task.

### Documentation
- [x] I have updated the Postman API details and Notion documentation as applicable

### Security
- [x] I have added validation rules for all the data/inputs from the users/browsers.
~- [] I have added/used respective permissions to the new routes/API endpoints for authorization.~

### Code quality/maintainability
- [x] I have run the Code Quality command.
- [x] I haven't used magic numbers anywhere in the code. constants/enums are used instead.
- [x] I have divided all the logic into respective domains and no code crosses its domain boundaries.
